### PR TITLE
Implement a non-destructive translate method

### DIFF
--- a/libchisel/src/deployer.rs
+++ b/libchisel/src/deployer.rs
@@ -60,7 +60,8 @@ fn deployer_code() -> Vec<u8> {
         4100410020001001200041046b2802002102200041046b20026b21012001200210
         020b
     ",
-    ).unwrap()
+    )
+    .unwrap()
 }
 
 /// Returns a module which contains the deployable bytecode as a custom section.
@@ -181,7 +182,8 @@ mod tests {
 
             000d086465706c6f79657200000000
         ",
-        ).unwrap();
+        )
+        .unwrap();
         let output = parity_wasm::serialize(module).expect("Failed to serialize");
         assert_eq!(output, expected);
     }
@@ -204,7 +206,8 @@ mod tests {
 
             0015086465706c6f79657280ff007faa55001108000000
         ",
-        ).unwrap();
+        )
+        .unwrap();
         let output = parity_wasm::serialize(module).expect("Failed to serialize");
         assert_eq!(output, expected);
     }
@@ -222,7 +225,8 @@ mod tests {
             696e697368000003030200010503010001071102046d61696e0001066d656d6f72
             7902000a0d0202000b08004100410010000b0b06010041000b00
         ",
-        ).unwrap();
+        )
+        .unwrap();
         let output = parity_wasm::serialize(module).expect("Failed to serialize");
         assert_eq!(output, expected);
     }
@@ -241,7 +245,8 @@ mod tests {
             7902000a0d0202000b08004100410810000b0b0e010041000b0880ff007faa5500
             11
         ",
-        ).unwrap();
+        )
+        .unwrap();
         let output = parity_wasm::serialize(module).expect("Failed to serialize");
         assert_eq!(output, expected);
     }

--- a/libchisel/src/lib.rs
+++ b/libchisel/src/lib.rs
@@ -16,7 +16,8 @@ pub trait ModuleCreator {
 }
 
 pub trait ModuleTranslator {
-    fn translate(self, module: &mut Module) -> Result<bool, String>;
+    fn translate(self, module: &Module) -> Result<Module, String>;
+    fn translate_inplace(self, module: &mut Module) -> Result<bool, String>;
 }
 
 pub trait ModuleValidator {
@@ -36,7 +37,10 @@ mod tests {
     }
 
     impl ModuleTranslator for SampleModule {
-        fn translate(self, module: &mut Module) -> Result<bool, String> {
+        fn translate(self, module: &Module) -> Result<Module, String> {
+            Ok(Module::default())
+        }
+        fn translate_inplace(self, module: &mut Module) -> Result<bool, String> {
             Ok((true))
         }
     }

--- a/libchisel/src/trimexports.rs
+++ b/libchisel/src/trimexports.rs
@@ -104,8 +104,14 @@ impl TrimExports {
 }
 
 impl ModuleTranslator for TrimExports {
-    fn translate(mut self, module: &mut Module) -> Result<bool, String> {
+    fn translate_inplace(mut self, module: &mut Module) -> Result<bool, String> {
         Ok(self.trim_exports(module))
+    }
+
+    fn translate(mut self, module: &Module) -> Result<Module, String> {
+        let mut ret = module.clone();
+        self.trim_exports(&mut ret);
+        Ok(ret)
     }
 }
 
@@ -137,7 +143,7 @@ mod tests {
             .build();
 
         let trimmer = TrimExports::with_preset("ewasm").unwrap();
-        let did_change = trimmer.translate(&mut module).unwrap();
+        let did_change = trimmer.translate_inplace(&mut module).unwrap();
         assert_eq!(false, did_change);
     }
 
@@ -168,7 +174,7 @@ mod tests {
             .build();
 
         let trimmer = TrimExports::with_preset("ewasm").unwrap();
-        let did_change = trimmer.translate(&mut module).unwrap();
+        let did_change = trimmer.translate_inplace(&mut module).unwrap();
         assert_eq!(true, did_change);
     }
 
@@ -184,7 +190,7 @@ mod tests {
             .build();
 
         let trimmer = TrimExports::with_preset("ewasm").unwrap();
-        let did_change = trimmer.translate(&mut module).unwrap();
+        let did_change = trimmer.translate_inplace(&mut module).unwrap();
         assert_eq!(false, did_change);
     }
 
@@ -205,7 +211,7 @@ mod tests {
             .build();
 
         let trimmer = TrimExports::with_preset("pwasm").unwrap();
-        let did_change = trimmer.translate(&mut module).unwrap();
+        let did_change = trimmer.translate_inplace(&mut module).unwrap();
         assert_eq!(false, did_change);
     }
 }

--- a/libchisel/src/verifyexports.rs
+++ b/libchisel/src/verifyexports.rs
@@ -128,11 +128,13 @@ fn has_table_export(section: &ExportSection, field: &str) -> bool {
 fn has_func_export(module: &Module, field: &str, sig: &FunctionType) -> bool {
     if let Some(section) = module.export_section() {
         match func_export_index_by_name(section, field) {
-            Some(index) => if let Some(resolved) = func_sig_by_index(module, index) {
-                *sig == *resolved
-            } else {
-                false
-            },
+            Some(index) => {
+                if let Some(resolved) = func_sig_by_index(module, index) {
+                    *sig == *resolved
+                } else {
+                    false
+                }
+            }
             None => false,
         }
     } else {
@@ -181,7 +183,8 @@ fn func_import_section_len(imports: &ImportSection) -> u32 {
         .filter(|e| match e.external() {
             &External::Function(_) => true,
             _ => false,
-        }).count() as u32
+        })
+        .count() as u32
 }
 
 /// Resolves a function export's index by name. Can be trivially adjusted for

--- a/libchisel/src/verifyimports.rs
+++ b/libchisel/src/verifyimports.rs
@@ -272,7 +272,8 @@ impl<'a> VerifyImports<'a> {
                         "selfDestruct",
                         FunctionType::new(vec![ValueType::I32], None),
                     ),
-                ].iter()
+                ]
+                .iter()
                 .cloned()
                 .collect(),
                 require_all: false,
@@ -389,32 +390,40 @@ impl<'a> ImportCheck for ImportType<'a> {
             {
                 match entry.external() {
                     // TODO: Wrap this in a helper.
-                    External::Function(idx) => if let Some(sig) = func_sig {
-                        if *sig == imported_func_sig_by_index(module, *idx as usize) {
+                    External::Function(idx) => {
+                        if let Some(sig) = func_sig {
+                            if *sig == imported_func_sig_by_index(module, *idx as usize) {
+                                ImportStatus::Good
+                            } else {
+                                ImportStatus::Malformed
+                            }
+                        } else {
+                            ImportStatus::Malformed
+                        }
+                    }
+                    // NOTE: There may be a better way to do mappings between enum variants.
+                    // Just check import variant here.
+                    External::Global(_idx) => {
+                        if let ImportType::Global(_n, _f) = self {
                             ImportStatus::Good
                         } else {
                             ImportStatus::Malformed
                         }
-                    } else {
-                        ImportStatus::Malformed
-                    },
-                    // NOTE: There may be a better way to do mappings between enum variants.
-                    // Just check import variant here.
-                    External::Global(_idx) => if let ImportType::Global(_n, _f) = self {
-                        ImportStatus::Good
-                    } else {
-                        ImportStatus::Malformed
-                    },
-                    External::Memory(_idx) => if let ImportType::Memory(_n, _f) = self {
-                        ImportStatus::Good
-                    } else {
-                        ImportStatus::Malformed
-                    },
-                    External::Table(_idx) => if let ImportType::Table(_n, _f) = self {
-                        ImportStatus::Good
-                    } else {
-                        ImportStatus::Malformed
-                    },
+                    }
+                    External::Memory(_idx) => {
+                        if let ImportType::Memory(_n, _f) = self {
+                            ImportStatus::Good
+                        } else {
+                            ImportStatus::Malformed
+                        }
+                    }
+                    External::Table(_idx) => {
+                        if let ImportType::Table(_n, _f) = self {
+                            ImportStatus::Good
+                        } else {
+                            ImportStatus::Malformed
+                        }
+                    }
                 }
             } else {
                 ImportStatus::NotFound
@@ -777,7 +786,8 @@ mod tests {
                 "ethereum",
                 "storageStore",
                 FunctionType::new(vec![ValueType::I32, ValueType::I32], None),
-            )].iter()
+            )]
+            .iter()
             .cloned()
             .collect(),
             allow_unlisted: false,
@@ -814,7 +824,8 @@ mod tests {
                 "ethereum",
                 "storageStore",
                 FunctionType::new(vec![ValueType::I32, ValueType::I32], None),
-            )].iter()
+            )]
+            .iter()
             .cloned()
             .collect(),
             allow_unlisted: true,
@@ -851,7 +862,8 @@ mod tests {
                 "ethereum",
                 "storageStore",
                 FunctionType::new(vec![ValueType::I32, ValueType::I32], None),
-            )].iter()
+            )]
+            .iter()
             .cloned()
             .collect(),
             allow_unlisted: false,
@@ -888,7 +900,8 @@ mod tests {
                 "ethereum",
                 "storageStore",
                 FunctionType::new(vec![ValueType::I32, ValueType::I32], None),
-            )].iter()
+            )]
+            .iter()
             .cloned()
             .collect(),
             allow_unlisted: false,


### PR DESCRIPTION
This second one returns a module as a result. The original method has been renamed to `translate_inplace`.
Closes #34 