### PR TITLE
add Dockerfile for chisel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM rust:1.34.0-stretch
+
+COPY . /chisel/
+
+RUN cd /chisel && cargo build --release
+
+ENTRYPOINT ["/chisel/target/release/chisel"]

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ ewasm:
     preset: "ewasm"
 ```
 
+## Docker
+
+Chisel can be invoked through Docker using `ewasm/chisel`:
+
+```
+docker run -v /path/to/host_workspace:/workspace -v /path/to/host/chisel.yml:/chisel.yml -t ewasm/wasm-chisel run
+```
+
 ## sentinel.rs
 
 TBA


### PR DESCRIPTION
Doesn't use the `ewasm/rust-wasm` docker image because the extra tooling isn't needed.