### PR TITLE
Module for removing start function (trimstartfunction)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ This comes with some presets:
 - `ewasm`: keeps `main` and exported memory
 - `pwasm`: keeps `_call`
 
+### trimstartfunc
+
+Remove start function.
+
+This comes with the following preset:
+- `ewasm`: removes `start` function if present
+
+
 ### verifyimports
 
 Verifies that the module's imports are compliant with the provided import interface.

--- a/chisel/src/main.rs
+++ b/chisel/src/main.rs
@@ -10,8 +10,8 @@ use std::fs::{read, read_to_string};
 use std::process;
 
 use libchisel::{
-    checkstartfunc::*, deployer::*, remapimports::*, trimexports::*, verifyexports::*,
-    verifyimports::*,
+    checkstartfunc::*, deployer::*, remapimports::*, trimexports::*, trimstartfunc::*,
+    verifyexports::*, verifyimports::*,
 };
 
 use clap::{App, Arg, ArgMatches, SubCommand};
@@ -218,10 +218,19 @@ fn execute_module(context: &ModuleContext, module: &mut Module) -> bool {
         }
         "trimexports" => {
             is_translator = true;
+
             if let Ok(chisel) = TrimExports::with_preset(&preset) {
                 translate_module(module, chisel)
             } else {
                 Err("trimexports: Invalid preset")
+            }
+        }
+        "trimstartfunc" => {
+            is_translator = true;
+            if let Ok(chisel) = TrimStartFunc::with_preset(&preset) {
+                translate_module(module, chisel)
+            } else {
+                Err("trimstartfunc: Invalid preset")
             }
         }
         "remapimports" => {

--- a/libchisel/src/lib.rs
+++ b/libchisel/src/lib.rs
@@ -10,6 +10,7 @@ pub mod checkstartfunc;
 pub mod deployer;
 pub mod remapimports;
 pub mod trimexports;
+pub mod trimstartfunc;
 pub mod verifyexports;
 pub mod verifyimports;
 

--- a/libchisel/src/trimstartfunc.rs
+++ b/libchisel/src/trimstartfunc.rs
@@ -1,0 +1,83 @@
+use super::{ModuleError, ModulePreset, ModuleTranslator};
+use parity_wasm::elements::*;
+
+pub struct TrimStartFunc;
+
+impl TrimStartFunc {
+    fn trim_startfunc(&self, module: &mut Module) -> bool {
+        if let Some(start_section) = module.start_section() {
+            module.clear_start_section();
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl ModulePreset for TrimStartFunc {
+    fn with_preset(preset: &str) -> Result<Self, ()> {
+        match preset {
+            "ewasm" => Ok(TrimStartFunc {}),
+            _ => Err(()),
+        }
+    }
+}
+
+impl ModuleTranslator for TrimStartFunc {
+    fn translate_inplace(&self, module: &mut Module) -> Result<bool, ModuleError> {
+        Ok(self.trim_startfunc(module))
+    }
+
+    fn translate(&self, module: &Module) -> Result<Option<Module>, ModuleError> {
+        Err(ModuleError::NotSupported)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use parity_wasm::elements::deserialize_buffer;
+
+    #[test]
+    fn start_removed() {
+        let wasm: Vec<u8> = vec![
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+            0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x6d, 0x61, 0x69, 0x6e, 0x00, 0x00,
+            0x08, 0x01, 0x00, 0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,
+        ];
+
+        let mut module = deserialize_buffer::<Module>(&wasm).unwrap();
+
+        let trimmer = TrimStartFunc::with_preset("ewasm").unwrap();
+        trimmer.translate_inplace(&mut module).unwrap();
+
+        let result = serialize::<Module>(module).unwrap();
+        let expect: Vec<u8> = vec![
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+            0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x6d, 0x61, 0x69, 0x6e, 0x00, 0x00,
+            0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,
+        ];
+
+        assert_eq!(expect, result);
+    }
+
+    #[test]
+    fn start_not_removed() {
+        let wasm: Vec<u8> = vec![
+            0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, 0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+            0x03, 0x02, 0x01, 0x00, 0x07, 0x08, 0x01, 0x04, 0x6d, 0x61, 0x69, 0x6e, 0x00, 0x00,
+            0x0a, 0x04, 0x01, 0x02, 0x00, 0x0b,
+        ];
+
+        let mut module = deserialize_buffer::<Module>(&wasm).unwrap();
+
+        let trimmer = TrimStartFunc::with_preset("ewasm").unwrap();
+        trimmer.translate_inplace(&mut module).unwrap();
+
+        let result = serialize::<Module>(module).unwrap();
+
+        // result is equal to initial wasm (not changed)
+        assert_eq!(result, wasm);
+    }
+}


### PR DESCRIPTION
Added code to trim the start function if present.

Here is an example of a chisel.yml using this functionality:

```yaml
ewasm:
  file: "build/optimized.wasm"
  output: "ewasm_token.wasm"
  trimstartfunc:
    preset: "ewasm"
```

The preset value is not being used, what would be the right configuration in  `chisel.yml`?
I was thinking something like this:

```yaml
ewasm:
  file: "build/optimized.wasm"
  output: "ewasm_token.wasm"
  trimstartfunc: true
```

@jakelang please take a look and let me know your comments.