### PR TITLE
CLI: return a zero exit code when a module is not modified during translation

### DIFF
--- a/chisel/src/main.rs
+++ b/chisel/src/main.rs
@@ -261,7 +261,11 @@ fn execute_module(context: &ModuleContext, module: &mut Module) -> bool {
     println!("\t{}: {}", name, module_status_msg);
 
     if let Ok(result) = ret {
-        result
+        if !result && is_translator {
+            true
+        } else {
+            result
+        }
     } else {
         false
     }


### PR DESCRIPTION
If I was using chisel in some kind of build pipeline and module translation resulted in no changes to the wasm, that would currently be interpreted as an error.