### PR TITLE
Properly declare wabt as a feature in CLI

### DIFF
--- a/chisel/Cargo.toml
+++ b/chisel/Cargo.toml
@@ -17,3 +17,7 @@ clap = "2.32.0"
 serde = "1.0.80"
 serde_derive = "1.0.80"
 serde_yaml = "0.8.7"
+
+[features]
+default = []
+wabt = [ "libchisel/wabt" ]


### PR DESCRIPTION
NOTE: it is called wabt-utils because a feature cannot be named the same as a dependency