### PR TITLE
Ignore .wasm and .wat files in source directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 Cargo.lock
 **/*.swp
 **/chisel.yml
+**/src/*.wasm
+**/src/*.wat


### PR DESCRIPTION
Tired of having the shell prompt tell me I have untracked files.
Makes it less annoying to prototype the CLI using test wasm files.