### PR TITLE
CLI: Introduce logging macro and global log level

### DIFF
--- a/chisel/src/logger.rs
+++ b/chisel/src/logger.rs
@@ -1,0 +1,31 @@
+static mut LOG_LEVEL: i32 = 0;
+
+#[macro_export]
+macro_rules! chisel_debug {
+    ($lvl:expr, $($arg:tt)*) => {
+        crate::logger::Logger::with_global_level().log($lvl, &format!($($arg)*));
+    }
+}
+
+/// Simple logging utility struct.
+pub struct Logger(i32);
+
+impl Logger {
+    pub fn with_global_level() -> Self {
+        unsafe { Logger(LOG_LEVEL) }
+    }
+
+    pub fn log<T: AsRef<str>>(&self, level: i32, message: T) {
+        if self.0 >= level {
+            eprintln!("{}", message.as_ref());
+        }
+    }
+}
+
+/// Set the global log level.
+// NOTE: Unsafe in a multithreaded context. Add mutex later when this is moved into the library.
+pub fn set_global_log_level(lvl: i32) {
+    unsafe {
+        LOG_LEVEL = lvl;
+    }
+}


### PR DESCRIPTION
Pulled from the CLI rewrite.
Also writes all user-facing messages to stderr, as primary program output goes in stdout (we don't have any as output is written to a file).

NOTE: Yes we are writing debug messages to stderr. The new CLI does this because unix mode will write wasm binaries to stdout unless otherwise specified. Does it matter in this PR? No, it will be overwritten by the other PR anyway.