### PR TITLE
Remove dependency on parity_wasm from chisel CLI

### DIFF
--- a/chisel/Cargo.toml
+++ b/chisel/Cargo.toml
@@ -12,7 +12,6 @@ edition = "2018"
 
 [dependencies]
 libchisel = { path = "../libchisel", version = "0.5.0" }
-parity-wasm = "^0.40.2"
 clap = "2.32.0"
 serde = "1.0.80"
 serde_derive = "1.0.80"

--- a/chisel/src/main.rs
+++ b/chisel/src/main.rs
@@ -309,7 +309,7 @@ fn execute_module(context: &ModuleContext, module: &mut Module) -> bool {
 
 fn chisel_execute(context: &ChiselContext) -> Result<bool, &'static str> {
     if let Ok(buffer) = read(context.file()) {
-        if let Ok(module) = module_from_bytes(&buffer) {
+        if let Ok(module) = Module::from_bytes(&buffer) {
             // If we do not parse the NamesSection here, parity-wasm will drop it at serialisation
             // It is useful to have this for a number of optimisation passes, including binaryenopt and snip
             // TODO: better error handling

--- a/chisel/src/main.rs
+++ b/chisel/src/main.rs
@@ -1,5 +1,4 @@
 extern crate libchisel;
-extern crate parity_wasm;
 #[macro_use]
 extern crate clap;
 extern crate serde;
@@ -10,7 +9,7 @@ extern crate serde_yaml;
 mod logger;
 mod config;
 
-use std::fs::{read, read_to_string};
+use std::fs::{read, read_to_string, write};
 use std::process;
 
 use libchisel::{
@@ -23,7 +22,6 @@ use libchisel::binaryenopt::*;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 use libchisel::*;
-use parity_wasm::elements::{deserialize_buffer, serialize_to_file, Module};
 use serde_yaml::Value;
 
 // Error messages
@@ -311,7 +309,7 @@ fn execute_module(context: &ModuleContext, module: &mut Module) -> bool {
 
 fn chisel_execute(context: &ChiselContext) -> Result<bool, &'static str> {
     if let Ok(buffer) = read(context.file()) {
-        if let Ok(module) = deserialize_buffer::<Module>(&buffer) {
+        if let Ok(module) = module_from_bytes(&buffer) {
             // If we do not parse the NamesSection here, parity-wasm will drop it at serialisation
             // It is useful to have this for a number of optimisation passes, including binaryenopt and snip
             // TODO: better error handling
@@ -327,12 +325,13 @@ fn chisel_execute(context: &ChiselContext) -> Result<bool, &'static str> {
 
             // If the module was mutated, serialize to file.
             if original != module {
+                let serialized = module.to_bytes().expect("Failed to serialize Module");
                 if let Some(path) = context.outfile() {
                     chisel_debug!(1, "Writing to file: {}", path);
-                    serialize_to_file(path, module).unwrap();
+                    write(path, serialized).unwrap();
                 } else {
                     chisel_debug!(1, "No output file specified; writing in place");
-                    serialize_to_file(context.file(), module).unwrap();
+                    write(context.file(), serialized).unwrap();
                 }
             }
             Ok(chisel_results)

--- a/libchisel/src/lib.rs
+++ b/libchisel/src/lib.rs
@@ -3,7 +3,7 @@ extern crate binaryen;
 extern crate parity_wasm;
 extern crate rustc_hex;
 
-use parity_wasm::elements::Module;
+pub use parity_wasm::elements::Module;
 
 use std::{error, fmt};
 

--- a/libchisel/src/lib.rs
+++ b/libchisel/src/lib.rs
@@ -28,11 +28,6 @@ pub mod verifyimports;
 
 mod depgraph;
 
-// This helper is exported here for users of this library not needing to import parity_wasm.
-pub fn module_from_bytes<T: AsRef<[u8]>>(input: T) -> Result<Module, ModuleError> {
-    Ok(Module::from_bytes(input)?)
-}
-
 #[derive(Eq, PartialEq, Debug)]
 pub enum ModuleKind {
     Creator,
@@ -249,18 +244,5 @@ mod tests {
 
         let result = as_trait.validate(&Module::default());
         assert!(result.is_ok());
-    }
-
-    #[test]
-    fn loading_from_bytes() {
-        let module_orig = Module::default();
-
-        let output = module_orig.clone().to_bytes().unwrap();
-        let module = module_from_bytes(&output).unwrap();
-        assert_eq!(module_orig, module);
-
-        let output = module_orig.clone().to_bytes().unwrap();
-        let module = Module::from_bytes(&output).unwrap();
-        assert_eq!(module_orig, module);
     }
 }


### PR DESCRIPTION
Follow up of #154. Also rolls back #150.